### PR TITLE
specify correct phase

### DIFF
--- a/models/mlsadf/mlsadf.py
+++ b/models/mlsadf/mlsadf.py
@@ -80,8 +80,8 @@ class MLSADF(nn.Module):
                 frame_period=hop_length,
                 alpha=self.alpha,
                 taylor_order=config.source_taylor_order,
-                phase="zero",
                 cep_order=config.source_cep_order,
+                phase="zero",
                 mode=config.mode,
             )
         elif config.mode == "single-stage":
@@ -111,8 +111,8 @@ class MLSADF(nn.Module):
                 frame_period=hop_length,
                 alpha=self.alpha,
                 taylor_order=config.filter_taylor_order,
-                phase="zero",
                 cep_order=config.filter_cep_order,
+                phase="minimum",
                 mode=config.mode,
             )
         elif config.mode == "single-stage":
@@ -121,7 +121,7 @@ class MLSADF(nn.Module):
                 frame_period=hop_length,
                 n_fft=n_fft,
                 alpha=self.alpha,
-                phase="zero",
+                phase="minimum",
                 mode=config.mode,
             )
         elif config.mode == "freq-domain":
@@ -132,6 +132,7 @@ class MLSADF(nn.Module):
                 fft_length=n_fft,
                 n_fft=n_fft,
                 alpha=self.alpha,
+                phase="minimum",
                 mode=config.mode,
             )
         self.pulse_generator = ExcitationGeneration(


### PR DESCRIPTION
[X上で指摘を受けた問題](https://x.com/prj_beatrice/status/1940403627065229545)を修正します。

`Mel-cepstral synthesis filter`(`H(z)`、実装内の`self.filter_mlsa`)では、MLSAモジュールの`phase`引数の指定をしておらず、MLSAモジュールの初期値(`phase="minimum"`)を使用していました。
ただ、`Aperiodic excitation filter`(`H_a(z)`、実装内の`self.source_mlsa`)及び`Periodic excitation filter`(`H_p(z)`)は [論文内](https://arxiv.org/pdf/2211.11222) 式(5) - (8)のうち、特に式(8)を満たすために`phase="zero"`を指定していました。

この、`phase="zero"`の指定が、リファクタリングの過程で誤って`self.filter_mlsa`にも挿入されており、誤った引数になっていたことから、これを修正し、明示的に`phase="minimum"`を引数として渡すようにします。

なお、記事に添付している各音声は、もとより`phase="zero"`の指定をしていなかった`config.mode == "freq-domain"`内の`self.filter_mlsa`で生成したものであったので、記事に変更は必要ないはずです。